### PR TITLE
chore: graph-tools default + project-name persistence

### DIFF
--- a/docs/workflow-map.md
+++ b/docs/workflow-map.md
@@ -179,7 +179,7 @@ Rules are in `rules/` and `CLAUDE.md`.
 | `rules/workflow-phases.md` | Jira + git phase sequence; two-source task sync (plan doc + journal; handoff as live pointer) | All Jira via `jira-workflow-manager`; all git via `git-manager`; all TODO.md via `plan-management` |
 | `rules/planning.md` | Plan doc format, sizing thresholds, naming, architect gate sequence | L-sized → plan doc required; design docs at `plans/<slug>/<slug>-design.md` |
 | `rules/plan-docs.md` | When plan docs are created, location, skip conditions | S/M → no plan doc; `plans/` is gitignored (session artifacts); committed docs go in `docs/` |
-| `rules/filesystem/efficiency.md` | Search and read patterns | No unscoped globs; plan-doc-first during execution; prefer graph tools over Grep |
+| `rules/filesystem/efficiency.md` | Search and read patterns | No unscoped globs; plan-doc-first during execution; **graph tools are the default** for code navigation when graph is present (Grep is fallback for non-source files); project name lives in project's CLAUDE.md "Codebase Knowledge Graph" section |
 | `rules/mcp-governance.md` | MCP tool access | No direct Atlassian MCP calls; JQL must include `project=` filter |
 | `rules/plugin-lifecycle.md` | Plugin routing, conflict suppression | Integrated plugins route via `creating-tools`; do not invoke directly |
 | `rules/cspell.md` | Spellcheck false positives | Auto-add to `cspell.json` and `.vscode/settings.json` without asking |

--- a/rules/filesystem/efficiency.md
+++ b/rules/filesystem/efficiency.md
@@ -33,20 +33,25 @@ Never call Glob with these patterns without a `path` parameter:
 
 Always scope with `path="src/function/"` or equivalent. A broad glob on a repo with 50+ files produces noise and consumes tokens with no gain over a targeted read.
 
-## Codebase Graph Tools (When Available)
+## Codebase Graph Tools — The Default for Code Navigation
 
-Prefer graph query tools over Grep for symbol navigation. Use Tool Search to find them:
+When a codebase graph is present (`.claude-init/CODEBASE.md` exists), graph tools are the **default** for symbol and code navigation. Grep is the **fallback** for non-source files (logs, generated output, configs) or when reading specific implementation logic the graph doesn't capture.
+
+Load the tools once per session via Tool Search: `ToolSearch("select:search_code,search_graph,query_graph,trace_path,get_architecture")`.
 
 | Need | Tool |
 |------|------|
-| Does this symbol exist? | `search_graph` |
+| Find a symbol or code by name/text | `search_code` (ranked, deduplicated) or `search_graph` |
 | What calls this function? | `query_graph` (Cypher: `MATCH (x)-[:CALLS]->(f:Function {name:"X"}) RETURN x`) |
 | What does this file import? | `query_graph` (Cypher: `MATCH (f {file:"X"})-[:IMPORTS]->(d) RETURN d`) |
 | Where is this env var defined? | Read `.claude-init/enrichments.json` directly |
 | What are the entry points? | `get_architecture` |
 | What routes are exposed? | `search_graph` (filter: Route nodes) |
+| Trace call chain between two symbols | `trace_path` |
 
-Use Grep only when no graph is present or when you need to read actual implementation logic.
+**Project name parameter.** Every graph tool requires a `project` argument. The canonical project name lives in the project's CLAUDE.md under "Codebase Knowledge Graph" — copy it from there. Do not derive it from the path; the slashes-to-hyphens conversion preserves internal underscores in unintuitive ways. If CLAUDE.md is missing the field, run `list_projects()` and use the entry whose `repo_path` matches the current working directory.
+
+Use Grep only when no graph is present, the file is non-source (logs, configs, generated output), or you need to read raw implementation logic that the graph doesn't capture.
 
 ## Plan-Doc-First Rule
 

--- a/rules/new-repo-setup.md
+++ b/rules/new-repo-setup.md
@@ -123,11 +123,12 @@ Never push directly to the production repository. All changes go to the sandbox 
 
 > Populated by `/infra-init` when run. Leave blank until then.
 
+- **Project name (codebase-memory-mcp):** `[filled by /infra-init from list_projects()]` — pass as the `project` parameter to all graph tool calls.
 - **Summary:** `.claude-init/CODEBASE.md` — generated: [date]
 - **Enrichments:** `.claude-init/enrichments.json` — env vars and serverless triggers
-- **Query tools:** `search_graph`, `query_graph`, `get_architecture`, `search_code`
+- **Query tools:** `search_graph`, `query_graph`, `get_architecture`, `search_code`, `trace_path`
 
-**Read `.claude-init/CODEBASE.md` first when starting any new task.** It contains repo type, entry points, and key modules. Use query tools for symbol-level lookups. Only fall back to Grep or direct file reads when the graph is absent or you need implementation logic the graph doesn't capture.
+**Read `.claude-init/CODEBASE.md` first when starting any new task.** It contains repo type, entry points, and key modules. Use query tools for symbol-level lookups — they are the default for code navigation. Fall back to Grep only for non-source files (logs, generated output, configs) or when the graph is absent.
 
 ---
 

--- a/skills/infra-init/SKILL.md
+++ b/skills/infra-init/SKILL.md
@@ -138,13 +138,16 @@ Wait for this agent to complete. It writes `.claude-init/CODEBASE.md` and sets `
 
 ## Post-Completion
 
-1. **Update the project's CLAUDE.md** — add or replace the codebase section:
+1. **Resolve the codebase-memory-mcp project name.** After indexing completes, call `list_projects()` and select the entry whose `repo_path` matches `meta.repo_path` from `progress.json`. Record its `name` field (the canonical project key — e.g. `Users-woosh-Documents-Repos-woosh_air_v4_claude`). Do not derive this client-side; the MCP server is the authority on its own key format.
+
+2. **Update the project's CLAUDE.md** — add or replace the codebase section:
 
    ```markdown
    ## Codebase Knowledge Graph
 
    Generated: <date>
 
+   - **Project name (codebase-memory-mcp):** `<project-name from list_projects>` — pass as the `project` parameter to `search_code`, `search_graph`, `query_graph`, `trace_path`, `get_architecture`.
    - Summary: `.claude-init/CODEBASE.md`
    - Env vars & serverless triggers: `.claude-init/enrichments.json`
    - `.claude-init/` is gitignored build output.
@@ -165,15 +168,16 @@ Wait for this agent to complete. It writes `.claude-init/CODEBASE.md` and sets `
    Read `.claude-init/enrichments.json` directly — not queryable via MCP tools.
    ```
 
-2. **Gitignore the build output.** Append to the target repo's `.gitignore` (create if absent, skip lines already present):
+3. **Gitignore the build output.** Append to the target repo's `.gitignore` (create if absent, skip lines already present):
 
    ```
    # /infra-init build output
    .claude-init/
    ```
 
-3. **Report to the user:**
+4. **Report to the user:**
    - Index status from `index_status()` result
+   - Project name from `list_projects()` (the value written into CLAUDE.md)
    - Paths to `CODEBASE.md` and `enrichments.json`
    - Any warnings logged by env var scan / serverless enrich
 
@@ -209,3 +213,4 @@ Wait for this agent to complete. It writes `.claude-init/CODEBASE.md` and sets `
 1. Requires python3.11 or python3.14 specifically — not generic python3.
 2. Call ToolSearch("select:index_repository") at Phase 2 start to verify codebase-memory-mcp is loaded.
 3. Phase 3 reads meta.repo_path from progress.json — verify it was written in Phase 2 before spawning the graph-builder agent.
+4. The codebase-memory-mcp project name is path-derived but the conversion (slashes→hyphens, internal underscores preserved) is non-obvious. Always pull it from `list_projects()` output — never construct it client-side.


### PR DESCRIPTION
## Summary
Resolves workflow-friction issues #22 and #24. Closes the activation-energy gap that pushes agents to grep over codebase-memory-mcp graph tools, and removes the trial-and-error project-name lookup that wasted 30+ min in #22.

## Changes
- **`skills/infra-init/SKILL.md`** — Post-Completion now resolves the canonical codebase-memory-mcp project name via `list_projects()` and writes it into the project CLAUDE.md as a "Project name (codebase-memory-mcp)" field. Added a gotcha: never derive the name client-side (the MCP server is the authority on its own key format).
- **`rules/new-repo-setup.md`** — Codebase Graph template gains the project-name field, marked as populated by /infra-init. Wording aligned with default (not preferred) graph-tools language. Added `trace_path` to query tools list.
- **`rules/filesystem/efficiency.md`** — "Codebase Graph Tools" section hardened from *"Prefer graph query tools over Grep"* to *"Graph tools are the **default** for code navigation. Grep is the **fallback** for non-source files (logs, generated output, configs)."* Added explicit `ToolSearch("select:search_code,search_graph,query_graph,trace_path,get_architecture")` invocation pattern. Added project-name-lookup paragraph pointing to CLAUDE.md.
- **`docs/workflow-map.md`** — Rule Governance row for `filesystem/efficiency.md` updated to reflect the new "default" prescription.

## Process
- Phoenix Checklist sweep run before proposing (saved at `plans/phoenix/codebase-memory-mcp-graph-tools-default.md`, gitignored). Frame shifts informed phasing — auto-loading graph tool schemas in `session-start.mjs` was deferred as highest-leverage but riskiest, needs a separate plan.
- Adversarial review pass found and fixed one flag: `workflow-map.md` description still said "prefer".

## Testing
- Manual: re-read each edited section for consistency. No tests apply (doc + rule changes only).
- Behavioral verification will come on next /infra-init run against a fresh repo — the resulting CLAUDE.md should contain the project-name field.

## Related issues
- Closes #22 — codebase-memory-mcp project-name derivation undocumented
- Closes #24 — graph tools should be default over grep, not just preferred
- Filed #28 (upstream MCP error-message gap — not actionable in this repo)